### PR TITLE
Add MongoDB storage and project API

### DIFF
--- a/app/add/page.tsx
+++ b/app/add/page.tsx
@@ -16,14 +16,21 @@ export default function AddProjectPage() {
   const [image, setImage] = useState('');
   const [addedProject, setAddedProject] = useState<Project | null>(null);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const newProject: Project = { title, description, link, image };
-    setAddedProject(newProject);
-    setTitle('');
-    setDescription('');
-    setLink('');
-    setImage('');
+    const res = await fetch('/api/projects', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, description, link, image }),
+    });
+    if (res.ok) {
+      const project: Project = await res.json();
+      setAddedProject(project);
+      setTitle('');
+      setDescription('');
+      setLink('');
+      setImage('');
+    }
   };
 
   return (

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+import connect from '@/lib/mongodb';
+import Project from '@/models/Project';
+
+export async function GET() {
+  await connect();
+  const projects = await Project.find().sort({ createdAt: -1 });
+  return NextResponse.json(projects);
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const data = await req.json();
+    await connect();
+    const project = await Project.create(data);
+    return NextResponse.json(project, { status: 201 });
+  } catch (error: any) {
+    return NextResponse.json({ message: error.message }, { status: 400 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
+"use client";
 import "bootstrap/dist/css/bootstrap.min.css";
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 type Project = {
   title: string;
@@ -9,29 +10,14 @@ type Project = {
 };
 
 export default function Home() {
-  const projects: Project[] = [
-    {
-      title: "Weather App",
-      description:
-        "A responsive weather app using React and OpenWeatherMap API. Shows current weather, forecasts, and location search.",
-      link: "https://your-weather-app.com",
-      image: "https://via.placeholder.com/600x300?text=Weather+App",
-    },
-    {
-      title: "Portfolio Website",
-      description:
-        "This personal portfolio built with React, Bootstrap, and TypeScript. Showcases my recent work and skills.",
-      link: "#",
-      image: "https://via.placeholder.com/600x300?text=Portfolio+Website",
-    },
-    {
-      title: "Task Manager",
-      description:
-        "A productivity-focused task manager app with Firebase backend, real-time updates, and user authentication.",
-      link: "https://your-task-manager.com",
-      image: "https://via.placeholder.com/600x300?text=Task+Manager",
-    },
-  ];
+  const [projects, setProjects] = useState<Project[]>([]);
+
+  useEffect(() => {
+    fetch("/api/projects")
+      .then((res) => res.json())
+      .then((data) => setProjects(data))
+      .catch(console.error);
+  }, []);
 
   return (
     <main style={{ scrollBehavior: "smooth" }}>

--- a/lib/mongodb.ts
+++ b/lib/mongodb.ts
@@ -1,0 +1,27 @@
+import mongoose from 'mongoose';
+
+const MONGODB_URI = process.env.MONGODB_URI as string;
+
+if (!MONGODB_URI) {
+  throw new Error('Please define the MONGODB_URI environment variable');
+}
+
+interface Cached {
+  conn: typeof mongoose | null;
+  promise: Promise<typeof mongoose> | null;
+}
+
+let cached = (global as any).mongoose as Cached | undefined;
+
+if (!cached) {
+  cached = (global as any).mongoose = { conn: null, promise: null };
+}
+
+export default async function connect() {
+  if (cached!.conn) return cached!.conn;
+  if (!cached!.promise) {
+    cached!.promise = mongoose.connect(MONGODB_URI);
+  }
+  cached!.conn = await cached!.promise;
+  return cached!.conn;
+}

--- a/models/Project.ts
+++ b/models/Project.ts
@@ -1,0 +1,13 @@
+import { Schema, model, models } from 'mongoose';
+
+const ProjectSchema = new Schema(
+  {
+    title: { type: String, required: true },
+    description: { type: String, required: true },
+    link: { type: String, required: true },
+    image: String,
+  },
+  { timestamps: true }
+);
+
+export default models.Project || model('Project', ProjectSchema);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "bootstrap": "^5.3.7",
     "next": "15.3.4",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "mongoose": "^8.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- install `mongoose` dependency
- add MongoDB connection helper
- create `Project` model with title, description, link and image
- implement `/api/projects` API with GET/POST
- send new project form via POST request
- fetch projects from API on home page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862313dcbd883268ba4cc04c897cae7